### PR TITLE
Updated unique suffix naming guidance

### DIFF
--- a/hands-on-labs/setup/asa-workspace-deploy.md
+++ b/hands-on-labs/setup/asa-workspace-deploy.md
@@ -58,7 +58,7 @@ Click the `Deploy to Azure` button below to start the deployment process.
 You should see next the `Custom deployment` screen where you need to provide the following (see [Pre-requisites for deployment](#pre-requisites-for-deployment) above for details):
 
 - The resource group where the Synapse Analytics workspace will be deployed.
-- The unique suffix used to generate the name of the workspace.
+- The unique suffix used to generate the name of the workspace (**NOTE**: Make sure this value has a **maximum** length of **5 characters**).
 - The password for the SQL Administrator account.
 
 Select `Review + create` to validate the settings.


### PR DESCRIPTION
I discovered that if the unique suffix is greater than 5 characters in length, the lab 2 deployment fails due to the cluster name exceeding 22 characters.